### PR TITLE
Use "release published" as our release event for asset uploading

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ Example:
 **Default**: `false`
 
 The `release-signing-artifacts` setting controls whether or not `sigstore-python`
-uploads signing artifacts to the release that triggered this run.
+uploads signing artifacts to the release publishing event that triggered this run.
 
 By default, no release assets are uploaded.
 

--- a/action.yml
+++ b/action.yml
@@ -113,6 +113,6 @@ runs:
         path: "${{ env.GHA_SIGSTORE_PYTHON_SIGNING_ARTIFACTS }}"
 
     - uses: softprops/action-gh-release@v1
-      if: inputs.release-signing-artifacts == 'true' && github.event_name == 'release' && github.event.action == 'created'
+      if: inputs.release-signing-artifacts == 'true' && github.event_name == 'release' && github.event.action == 'published'
       with:
         files: "${{ env.GHA_SIGSTORE_PYTHON_SIGNING_ARTIFACTS }}"


### PR DESCRIPTION
This more accurately reflects the release lifecycle.