### PR TITLE
workflows/release: add a release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+on:
+  release:
+    types:
+      - published
+
+name: release
+
+permissions:
+  # Used to sign the release's artifacts with sigstore-python.
+  id-token: write
+
+  # Used to attach signing artifacts to the published release.
+  contents: write
+
+jobs:
+  pypi:
+    - uses: actions/checkout@v3
+
+    - name: sign
+      uses: ./
+      id: sigstore-python
+      with:
+        inputs: action.yml action.py
+        upload-signing-artifacts: true


### PR DESCRIPTION
This effectively serves as another self-test, by ensuring that we attach signing artifacts to releases correctly.

Signed-off-by: William Woodruff <william@trailofbits.com>