### PR TITLE
requirements: sigstore==0.6.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,1 @@
-sigstore==0.6.4
-
-# TODO: remove this constraint once sigstore itself enforces it
-pyOpenSSL>=22.0.0
+sigstore==0.6.5


### PR DESCRIPTION
Remove obsolete transitive constraint.

Signed-off-by: William Woodruff <william@trailofbits.com>